### PR TITLE
Replace fixed-width integer types with their fast variants when possible

### DIFF
--- a/lz78-naive/io.c
+++ b/lz78-naive/io.c
@@ -148,7 +148,7 @@ bool read_pair(int fd, Code *c, Symbol *s, int width) {
 void buffer_word(int fd, Word *w) {
   total_syms += w->len;
 
-  for (uint32_t i = 0; i < w->len; i += 1) {
+  for (uint_fast32_t i = 0; i < w->len; i += 1) {
     symbuf[syms++] = w->syms[i];
 
     if (syms == BLOCK) {

--- a/lz78-naive/trie.c
+++ b/lz78-naive/trie.c
@@ -19,7 +19,7 @@ TrieNode *trie_create(void) {
 }
 
 void trie_reset(TrieNode *root) {
-  for (uint16_t i = 0; i < ALPHABET; i += 1) {
+  for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
     if (root->children[i]) {
       trie_delete(root->children[i]);
       root->children[i] = NULL;
@@ -31,7 +31,7 @@ void trie_reset(TrieNode *root) {
 
 void trie_delete(TrieNode *n) {
   if (n) {
-    for (uint16_t i = 0; i < ALPHABET; i += 1) {
+    for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
       trie_delete(n->children[i]);
     }
 

--- a/lz78-naive/word.c
+++ b/lz78-naive/word.c
@@ -51,7 +51,7 @@ WordTable *wt_create(void) {
 }
 
 void wt_reset(WordTable *wt) {
-  for (uint32_t i = START; i < MAX; i += 1) {
+  for (uint_fast32_t i = START; i < MAX; i += 1) {
     if (wt[i]) {
       word_delete(wt[i]);
       wt[i] = NULL;
@@ -62,7 +62,7 @@ void wt_reset(WordTable *wt) {
 }
 
 void wt_delete(WordTable *wt) {
-  for (uint32_t i = EMPTY; i < MAX; i += 1) {
+  for (uint_fast32_t i = EMPTY; i < MAX; i += 1) {
     if (wt[i]) {
       word_delete(wt[i]);
       wt[i] = NULL;

--- a/lz78-optimized/io.c
+++ b/lz78-optimized/io.c
@@ -78,7 +78,7 @@ void buffer_pair(int fd, Code c, Symbol s, int width) {
     }
   }
 
-  for (int i = 0; i < BYTE; i += 1) {
+  for (uint_fast8_t i = 0; i < BYTE; i += 1) {
     if (s & (1 << i)) {
       bitbuf[bits / BYTE] |= (1 << (bits % BYTE));
     }
@@ -121,7 +121,7 @@ bool read_pair(int fd, Code *c, Symbol *s, int width) {
     bits = (bits + 1) % (BLOCK * BYTE);
   }
 
-  for (int i = 0; i < BYTE; i += 1) {
+  for (uint_fast8_t i = 0; i < BYTE; i += 1) {
     if (!bits) {
       read_bytes(fd, bitbuf, BLOCK);
     }

--- a/lzw-naive/io.c
+++ b/lzw-naive/io.c
@@ -116,7 +116,7 @@ bool read_code(int fd, Code *c, int width) {
 void buffer_word(int fd, Word *w) {
   total_syms += w->len;
 
-  for (uint32_t i = 0; i < w->len; i += 1) {
+  for (uint_fast32_t i = 0; i < w->len; i += 1) {
     symbuf[syms++] = w->syms[i];
 
     if (syms == BLOCK) {

--- a/lzw-naive/trie.c
+++ b/lzw-naive/trie.c
@@ -17,7 +17,7 @@ void trie_node_delete(TrieNode *n) {
 TrieNode *trie_create(void) {
   TrieNode *root = trie_node_create(0);
 
-  for (uint16_t i = 0; i < ALPHABET; i += 1) {
+  for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
     root->children[i] = trie_node_create(i);
   }
 
@@ -25,8 +25,8 @@ TrieNode *trie_create(void) {
 }
 
 void trie_reset(TrieNode *root) {
-  for (uint16_t i = 0; i < ALPHABET; i += 1) {
-    for (uint16_t j = 0; j < ALPHABET; j += 1) {
+  for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
+    for (uint_fast16_t j = 0; j < ALPHABET; j += 1) {
       if (root->children[i]->children[j]) {
         trie_delete(root->children[i]->children[j]);
         root->children[i]->children[j] = NULL;
@@ -39,7 +39,7 @@ void trie_reset(TrieNode *root) {
 
 void trie_delete(TrieNode *n) {
   if (n) {
-    for (uint16_t i = 0; i < ALPHABET; i += 1) {
+    for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
       trie_delete(n->children[i]);
     }
 

--- a/lzw-naive/word.c
+++ b/lzw-naive/word.c
@@ -38,7 +38,7 @@ WordTable *wt_create(void) {
   WordTable *wt = (WordTable *) calloc(MAX, sizeof(Word *));
   check(wt, "Failed to calloc() word table");
 
-  for (uint16_t i = 0; i < ALPHABET; i += 1) {
+  for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
     wt[i] = word_create((Symbol *)&i, 1);
   }
 
@@ -46,7 +46,7 @@ WordTable *wt_create(void) {
 }
 
 void wt_reset(WordTable *wt) {
-  for (uint32_t i = ALPHABET; i < MAX; i += 1) {
+  for (uint_fast32_t i = ALPHABET; i < MAX; i += 1) {
     if (wt[i]) {
       word_delete(wt[i]);
       wt[i] = NULL;
@@ -57,7 +57,7 @@ void wt_reset(WordTable *wt) {
 }
 
 void wt_delete(WordTable *wt) {
-  for (uint32_t i = 0; i < MAX; i += 1) {
+  for (uint_fast32_t i = 0; i < MAX; i += 1) {
     if (wt[i]) {
       word_delete(wt[i]);
       wt[i] = NULL;

--- a/lzw-optimized/trie.c
+++ b/lzw-optimized/trie.c
@@ -3,8 +3,8 @@
 static Code trie[MAX][ALPHABET];
 
 void trie_init(void) {
-  for (uint32_t i = 0; i < MAX; i += 1) {
-    for (uint16_t j = 0; j < ALPHABET; j += 1) {
+  for (uint_fast32_t i = 0; i < MAX; i += 1) {
+    for (uint_fast16_t j = 0; j < ALPHABET; j += 1) {
       if (i == EMPTY) {
         trie[i][j] = j;
       } else {

--- a/lzw-optimized/word.c
+++ b/lzw-optimized/word.c
@@ -5,13 +5,13 @@ static Symbol syms[MAX];
 static Symbol first[MAX];
 
 void wt_init(void) {
-  for (uint32_t i = 0; i < ALPHABET; i += 1) {
+  for (uint_fast16_t i = 0; i < ALPHABET; i += 1) {
     syms[i]  = i;
     first[i] = i;
     codes[i] = EMPTY;
   }
 
-  for (uint32_t i = ALPHABET; i < MAX; i += 1) {
+  for (uint_fast16_t i = ALPHABET; i < MAX; i += 1) {
     codes[i] = STOP;
   }
 


### PR DESCRIPTION
Using types like uint_fast8_t will optimize for speed based on the compiler.
This seems to be the better choice considering how little memory is used
already. In benchmarks, this uses slightly less time in `trie_init`.

Also, hi! :)